### PR TITLE
Index order

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -2,7 +2,7 @@ class ReviewsController < ApplicationController
 
   def index
     @friends = current_user.friends
-    @reviews = Review.where(user: @friends).or(Review.where(user: current_user))
+    @reviews = Review.where(user: @friends).or(Review.where(user: current_user)).order(created_at: :asc)
   end
 
   def new

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -2,7 +2,7 @@ class ReviewsController < ApplicationController
 
   def index
     @friends = current_user.friends
-    @reviews = Review.where(user: @friends).or(Review.where(user: current_user)).order(created_at: :asc)
+    @reviews = Review.where(user: @friends).or(Review.where(user: current_user)).order(created_at: :desc)
   end
 
   def new

--- a/app/views/reviews/index.html.erb
+++ b/app/views/reviews/index.html.erb
@@ -4,7 +4,7 @@
   <h1>Your feed</h1>
 </div>
 
-  <% @reviews.each do |review| %>
+  <% @reviews.reverse_each do |review| %>
     <div class="feed-review">
       <p class="review-intro"><strong><%= review.user.first_name %></strong> left a review for <strong><%=review.restaurant.name%></strong>... </p>
       <%= render "shared/review_card", review: review %>


### PR DESCRIPTION
The order of reviews on the home page **_should_** be updated to show the newest review first, my local host was weirdly showing the opposite order to heroku. When we push to heroku, if the order isn't correct I can just reverse the order direction to hopefully sort it out. 🤠